### PR TITLE
set non-uniqueness value on foreign keys for has many relationship

### DIFF
--- a/src/models/contact.js
+++ b/src/models/contact.js
@@ -21,7 +21,11 @@ module.exports = (sequelize, DataTypes) => {
   Contact.associate = models => {
     // associations can be defined here
     Contact.hasMany(models.Referral, {
-      foreignKey: 'referrerId',
+      foreignKey: {
+        name : 'referrerId',
+        unique: false,
+        allowNull: true
+      },
       as: 'Referrers'
     })
     Contact.belongsToMany(models.Event, {

--- a/src/models/referral.js
+++ b/src/models/referral.js
@@ -21,7 +21,11 @@ module.exports = (sequelize, DataTypes) => {
   Referral.associate = models => {
     // associations can be defined here
     Referral.belongsTo(models.Contact, {
-      foreignKey: 'referrerId',
+      foreignKey: {
+        name : 'referrerId',
+        unique: false,
+        allowNull: true
+      },
       onDelete: 'CASCADE'
     })
     Referral.belongsToMany(models.Event, {


### PR DESCRIPTION
#### What does this PR do?
Fixes `SequelizeUniqueConstraintError` error in `hasMany` relation.

#### How should it be tested?
- Drop the current test database with the command:
```
dropdb {test_db_name}
```
- recreate test database with the command:
```
createdb {test_db_name}
```
- run all tests with the command:
```
npm t
```
- notice that no `SequelizeUniqueConstraintError` error appears during test running.